### PR TITLE
feat(meeting): update meetingkit 4.4.0

### DIFF
--- a/SampleCode/Android/CHANGELOG.md
+++ b/SampleCode/Android/CHANGELOG.md
@@ -1,4 +1,114 @@
 # NEMeetingKit ChangeLog
+## v4.4.0(April 2, 2024)
+### New Feature
+- 入会时支持指定参会者头像：`NEMeetingParams.avatar`
+- 入会时支持是否允许音频设备切换`NEMeetingOptions.enableAudioDeviceSwitch`
+- 支持会中锁定特定用户视频画面
+- 支持会议创建者收回主持人权限
+- 预约会议支持配置是否允许参会者在主持人进会前加入会议: `NEMeetingItem.setEnableJoinBeforeHost`, `NEMeetingItem.isEnableJoinBeforeHost` 
+- Android 升级适配 TargetSdk 至 API 34 （Android 14）
+  - 声明了 POST_NOTIFICATION 权限（暂不执行动态申请）
+  - 调整了 Android 14 上启动前台 Service 的时机至用户授权屏幕共享权限后
+- 支持会中全部准入、全部移除等候室成员
+- 支持本次会议自动准入等候室成员
+- 支持聊天室私聊功能和聊天权限控制
+### Fixed
+- 修复等候室默认图片展示未撑满屏幕的问题
+- 适配 Android 机型导航栏沉浸式模式
+- 参会者列表添加“焦点视频”成员图标
+- 修复 Android 5.x 系统白板共享黑屏问题（Flutter渲染PlatformView 失败）
+- 兼容处理 会中聊天室/等候室聊天室 可能不存在的情况
+### Api Changes
+- 废弃 `NELoggerConfig` ，不再支持配置日志级别和日志文件路径
+### Compatibility
+- 兼容 NERoomKit 1.27.0
+- 兼容 NIMSDK_LITE 9.15.0
+- 兼容 NERtcSDK  5.5.33
+
+## v4.3.1(March 7, 2024)
+### Bug Fixes
+- 修改会议邀请文本
+### Compatibility
+- 兼容 NERoomKit 1.26.0
+- 兼容 NIMSDK_LITE 9.14.2
+- 兼容 NERtcSDK  5.5.22
+
+## v4.3.0(March 7, 2024)
+### New Feature
+- 新增断开音频功能，支持连接/断开本地音频
+- 新增获取音频列表、切换音频设备功能
+- 支持管理员修改参会者昵称
+- 支持用户头像显示
+### Compatibility
+- 兼容 NERoomKit 1.26.0
+- 兼容 NIMSDK_LITE 9.14.2
+- 兼容 NERtcSDK  5.5.22
+
+## v4.2.2(Jan 31, 2024)
+### New Feature
+- 升级 NERtc 版本至 5.5.21
+### Compatibility
+- 兼容 NERoomKit 1.25.2
+- 兼容 NIMSDK_LITE 9.14.1
+- 兼容 NERtcSDK  5.5.21
+
+## v4.2.1(Jan 24, 2024)
+### Bug Fixes
+- 修复appKey未配置等候室，加入聊天室失败问题
+### Compatibility
+- 兼容 NERoomKit 1.25.1
+- 兼容 NIMSDK_LITE 9.14.1
+- 兼容 NERtcSDK  5.5.207
+
+## v4.1.1(Jan 15, 2024)
+### New Feature
+- 升级 NERtc 版本至 5.5.207
+
+### Compatibility
+- 兼容 NERoomKit 1.25.1
+- 兼容 NIMSDK_LITE 9.14.1
+- 兼容 NERtcSDK 5.5.207
+
+## v4.1.0(Jan 10, 2024)
+### New Feature
+- 新增等候室功能
+  - 等候室开启后，新参会者会先进入等候室，管理员可以准入或者移除等候室中的参会者
+  - 会中管理员可以在聊天室给等候室所有成员发消息，等候室成员可以查看等候室的聊天消息
+  - 创建会议时，通过 `NEStartMeetingOptions.enableWaitingRoom` 设置会议是否开启等候室，管理员后续可以手动开关
+  - 预约会议时，通过 `NEMeetingItem.setWaitingRoomEnabled` 设置会议是否开启等候室
+- 新增会议水印功能，可以在会议中开启水印，后台可以配置水印内容、水印样式、是否强制打开(强制打开则端上不展示设置入口)
+- 修改会控更多工具栏展示，新增安全模块，支持等候室开关、水印开关和锁定会议开关
+- 新增接口 `NEMeetingService.updateInjectedMenuItem`，更新当前存在的自定义菜单项的信息和状态
+- `NEAccountService.getAccountInfo` 账号信息查询新增字段： `NEAccountInfo.accountId`，`NEAccountInfo.isAnonymous`
+
+### Compatibility
+- 兼容 NERoomKit 1.25.0
+- 兼容 NIMSDK_LITE 9.14.1
+- 兼容 NERtcSDK  5.5.203
+
+## v4.0.1(Dec 29, 2023)
+### New Feature
+- 新增updateInjectedMenuItem接口，支持动态修改已存在的菜单按钮状态
+- AccountService.getAccountInfo返回增加accountId、isAnonymous，支持获取匿名入会的账号信息
+
+### Compatibility
+- 兼容 NERoomKit 1.23.1
+- 兼容 NIMSDK_LITE 9.12.0
+- 兼容 NERtcSDK  5.5.203
+
+## v4.0.0(Nov 30, 2023)
+### New Feature
+- 新增云端录制会议能力。
+- 支持在会议中查询历史消息和撤回消息。
+- 在会议配置项 NEMeetingOptions 中新增以下属性：
+  - showCloudRecordMenuItem：是否展示云端录制菜单按钮，默认为 true。
+  - showCloudRecordingUI：是否展示云端录制过程中的UI提示，默认为 true。
+
+### Compatibility
+- 兼容 NERoomKit 1.23.0
+- 兼容 NIMSDK_LITE 9.12.0
+- 兼容 NERtcSDK  5.5.203
+
 ## v3.17.0 (Oct 31, 2023)
 
 ### New Features

--- a/SampleCode/Android/README.md
+++ b/SampleCode/Android/README.md
@@ -16,7 +16,7 @@
 * Kotlin
 ```
 dependencies {
-    val meetingkit_version = "3.17.0"
+    val meetingkit_version = "4.4.0"
     implementation("com.netease.yunxin.kit.meeting:meeting:$meetingkit_version")
 }
 ```
@@ -24,7 +24,7 @@ dependencies {
 * Groovy
 ```
 dependencies {
-    def meetingkit_version = "3.17.0"
+    def meetingkit_version = "4.4.0"
     implementation "com.netease.yunxin.kit.meeting:meeting:$meetingkit_version"
 }
 ```

--- a/SampleCode/Android/app/build.gradle
+++ b/SampleCode/Android/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     viewBinding {
         enabled = true
@@ -11,9 +11,9 @@ android {
     defaultConfig {
         applicationId "com.netease.yunxin.kit.meeting.sampleapp"
         minSdkVersion 21
-        targetSdkVersion 31
-        versionCode 31700
-        versionName "3.17.0"
+        targetSdkVersion 34
+        versionCode 40400
+        versionName "4.4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -43,7 +43,7 @@ repositories {
 }
 dependencies {
     // meeting
-    implementation 'com.netease.yunxin.kit.meeting:meeting:3.17.0'
+    implementation 'com.netease.yunxin.kit.meeting:meeting:4.4.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3'
@@ -68,6 +68,6 @@ dependencies {
     implementation "androidx.navigation:navigation-ui-ktx:2.3.0"
     implementation 'com.manu:MDatePicker:1.0.1'
 
-    compileOnly 'com.netease.yunxin:nertc-full:4.6.13'
-    compileOnly 'com.netease.nimlib:basesdk:9.6.4'
+    compileOnly 'com.netease.yunxin:nertc-full:5.5.33'
+    compileOnly 'com.netease.nimlib:basesdk:9.15.0'
 }

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/SdkAuthenticator.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/SdkAuthenticator.java
@@ -229,11 +229,24 @@ public class SdkAuthenticator implements SdkInitializer.InitializeListener {
   }
 
   public static String getAccount() {
+    return getAccount(null, null);
+  }
+
+  public static String getAccount(String defaultAccount) {
+    return getAccount(defaultAccount, null);
+  }
+
+  public static String getAccount(String defaultAccount, Integer maxLength) {
+    if (defaultAccount == null || defaultAccount.length() == 0) {
+      defaultAccount = "xxxx";
+    }
     String nickName;
     nickName = SPUtils.getInstance().getString(KEY_NICK_NAME);
     if (TextUtils.isEmpty(nickName)) {
-      nickName = SPUtils.getInstance().getString(KEY_ACCOUNT, "xxxx");
-      nickName = nickName.substring(Math.max(nickName.length() - 4, 0));
+      nickName = SPUtils.getInstance().getString(KEY_ACCOUNT, defaultAccount);
+      if (maxLength != null) {
+        nickName = nickName.substring(Math.max(nickName.length() - maxLength, 0));
+      }
     }
     return nickName;
   }

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/SdkInitializer.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/SdkInitializer.java
@@ -11,11 +11,8 @@ import android.net.NetworkCapabilities;
 import android.net.NetworkRequest;
 import android.util.Log;
 import androidx.annotation.NonNull;
-import com.netease.yunxin.kit.meeting.R;
 import com.netease.yunxin.kit.meeting.sampleapp.data.ServerConfig;
 import com.netease.yunxin.kit.meeting.sampleapp.utils.SPUtils;
-import com.netease.yunxin.kit.meeting.sdk.NELogLevel;
-import com.netease.yunxin.kit.meeting.sdk.NELoggerConfig;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingError;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingKit;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingKitConfig;
@@ -128,14 +125,6 @@ public class SdkInitializer {
     config.appName = context.getString(R.string.app_name);
     config.serverUrl = serverConfig.getServerUrl();
     config.useAssetServerConfig = serverConfig.getUseAssetServerConfig();
-    //配置会议时显示前台服务
-    // NEForegroundServiceConfig foregroundServiceConfig = new NEForegroundServiceConfig();
-    // foregroundServiceConfig.contentTitle = context.getString(R.string.app_name);
-    // config.foregroundServiceConfig = foregroundServiceConfig;
-    NELoggerConfig loggerConfig = new NELoggerConfig();
-    loggerConfig.level = NELogLevel.of(getLoggerLevelConfig());
-    loggerConfig.path = getLoggerPathConfig();
-    config.loggerConfig = loggerConfig;
     NEMeetingKit.getInstance()
         .initialize(
             context,

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/SimpleMeetingEncryptor.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/SimpleMeetingEncryptor.java
@@ -6,11 +6,16 @@ package com.netease.yunxin.kit.meeting.sampleapp;
 
 import android.content.SharedPreferences;
 import android.util.Log;
+import com.netease.lava.nertc.sdk.NERtcEx;
+import com.netease.lava.nertc.sdk.encryption.NERtcEncryptionConfig;
+import com.netease.lava.nertc.sdk.encryption.NERtcPacket;
+import com.netease.lava.nertc.sdk.encryption.NERtcPacketObserver;
 import com.netease.yunxin.kit.meeting.sampleapp.log.LogUtil;
 import com.netease.yunxin.kit.meeting.sampleapp.utils.SPUtils;
 import com.netease.yunxin.kit.meeting.sdk.NEGlobalEventListener;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingKit;
 import com.netease.yunxin.kit.meeting.sdk.NERtcWrapper;
+import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SimpleMeetingEncryptor extends NEGlobalEventListener
@@ -73,72 +78,80 @@ public class SimpleMeetingEncryptor extends NEGlobalEventListener
   @Override
   public void afterRtcEngineInitialize(String meetingNum, NERtcWrapper rtcWrapper) {
     Log.d(TAG, "afterRtcEngineInitialize: meetingNum=" + meetingNum);
-    // if (enableAudioEncryption || enableVideoEncryption) {
-    //   NERtcEx rtcEngine = rtcWrapper.getRtcEngine();
-    //   int result = rtcEngine.registerPacketObserver(new PacketObserver());
-    //   LogUtil.log(TAG, "registerPacketObserver result: " + result);
-    // }
+    if (enableAudioEncryption || enableVideoEncryption) {
+      NERtcEx rtcEngine = rtcWrapper.getRtcEngine();
+      int result =
+          rtcEngine.enableEncryption(
+              true,
+              new NERtcEncryptionConfig(
+                  NERtcEncryptionConfig.EncryptionMode.EncryptionModeCustom,
+                  /// mode选择内置加密时有效，选择自定义加密时无效
+                  null,
+                  /// 自定义加密回调 observer, mode 为自定义加密时需要设置
+                  new PacketObserver()));
+      LogUtil.log(TAG, "registerPacketObserver result: " + result);
+    }
   }
 
   @Override
   public void beforeRtcEngineRelease(String meetingNum, NERtcWrapper rtcWrapper) {
     Log.d(TAG, "beforeRtcEngineRelease: meetingNum=" + meetingNum);
-    // int result = rtcWrapper.getRtcEngine().registerPacketObserver(null);
-    // LogUtil.log(TAG, "unregisterPacketObserver result: " + result);
+    int result = rtcWrapper.getRtcEngine().enableEncryption(false, null);
+    LogUtil.log(TAG, "unregisterPacketObserver result: " + result);
   }
 
-  // private class PacketObserver implements NERtcPacketObserver {
-  //
-  //   @Override
-  //   public boolean onSendAudioPacket(NERtcPacket neRtcPacket) {
-  //     if (enableAudioEncryption) {
-  //       ByteBuffer buffer = neRtcPacket.getData();
-  //       neRtcPacket.setData(encrypt(buffer, neRtcPacket.getSize()));
-  //     }
-  //     return true;
-  //   }
-  //
-  //   @Override
-  //   public boolean onSendVideoPacket(NERtcPacket neRtcPacket) {
-  //     if (enableVideoEncryption) {
-  //       ByteBuffer buffer = neRtcPacket.getData();
-  //       neRtcPacket.setData(encrypt(buffer, neRtcPacket.getSize()));
-  //     }
-  //     return true;
-  //   }
-  //
-  //   @Override
-  //   public boolean onReceiveAudioPacket(NERtcPacket neRtcPacket) {
-  //     if (enableAudioEncryption) {
-  //       ByteBuffer buffer = neRtcPacket.getData();
-  //       neRtcPacket.setData(decrypt(buffer, neRtcPacket.getSize()));
-  //     }
-  //     return true;
-  //   }
-  //
-  //   @Override
-  //   public boolean onReceiveVideoPacket(NERtcPacket neRtcPacket) {
-  //     if (enableVideoEncryption) {
-  //       ByteBuffer buffer = neRtcPacket.getData();
-  //       neRtcPacket.setData(decrypt(buffer, neRtcPacket.getSize()));
-  //     }
-  //     return true;
-  //   }
-  //
-  //   private ByteBuffer encrypt(ByteBuffer buffer, int size) {
-  //     for (int i = 0; i < size; i++) {
-  //       byte b = buffer.get(i);
-  //       buffer.put(i, (byte) ~(b & 0xFF));
-  //     }
-  //     return buffer;
-  //   }
-  //
-  //   private ByteBuffer decrypt(ByteBuffer buffer, int size) {
-  //     for (int i = 0; i < size; i++) {
-  //       byte b = buffer.get(i);
-  //       buffer.put(i, (byte) ~(b & 0xFF));
-  //     }
-  //     return buffer;
-  //   }
-  // };
+  private class PacketObserver implements NERtcPacketObserver {
+
+    @Override
+    public boolean onSendAudioPacket(NERtcPacket neRtcPacket) {
+      if (enableAudioEncryption) {
+        ByteBuffer buffer = neRtcPacket.getData();
+        neRtcPacket.setData(encrypt(buffer, neRtcPacket.getSize()));
+      }
+      return true;
+    }
+
+    @Override
+    public boolean onSendVideoPacket(NERtcPacket neRtcPacket) {
+      if (enableVideoEncryption) {
+        ByteBuffer buffer = neRtcPacket.getData();
+        neRtcPacket.setData(encrypt(buffer, neRtcPacket.getSize()));
+      }
+      return true;
+    }
+
+    @Override
+    public boolean onReceiveAudioPacket(NERtcPacket neRtcPacket) {
+      if (enableAudioEncryption) {
+        ByteBuffer buffer = neRtcPacket.getData();
+        neRtcPacket.setData(decrypt(buffer, neRtcPacket.getSize()));
+      }
+      return true;
+    }
+
+    @Override
+    public boolean onReceiveVideoPacket(NERtcPacket neRtcPacket) {
+      if (enableVideoEncryption) {
+        ByteBuffer buffer = neRtcPacket.getData();
+        neRtcPacket.setData(decrypt(buffer, neRtcPacket.getSize()));
+      }
+      return true;
+    }
+
+    private ByteBuffer encrypt(ByteBuffer buffer, int size) {
+      for (int i = 0; i < size; i++) {
+        byte b = buffer.get(i);
+        buffer.put(i, (byte) ~(b & 0xFF));
+      }
+      return buffer;
+    }
+
+    private ByteBuffer decrypt(ByteBuffer buffer, int size) {
+      for (int i = 0; i < size; i++) {
+        byte b = buffer.get(i);
+        buffer.put(i, (byte) ~(b & 0xFF));
+      }
+      return buffer;
+    }
+  };
 }

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/adapter/ScheduleMeetingAdapter.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/adapter/ScheduleMeetingAdapter.java
@@ -4,7 +4,6 @@
 package com.netease.yunxin.kit.meeting.sampleapp.adapter;
 
 import android.content.Context;
-import android.os.Build;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -13,7 +12,6 @@ import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.TextView;
-import androidx.annotation.RequiresApi;
 import androidx.lifecycle.MutableLiveData;
 import com.kyleduo.switchbutton.SwitchButton;
 import com.netease.yunxin.kit.meeting.sampleapp.SdkAuthenticator;
@@ -65,7 +63,6 @@ public class ScheduleMeetingAdapter
     return VIEW_TYPE;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
   @Override
   public void convert(ScheduleMeetingItem data, int position, VH<ItemScheduleMeetingBinding> vh) {
     final ItemScheduleMeetingBinding binding = vh.viewBinding;
@@ -125,7 +122,7 @@ public class ScheduleMeetingAdapter
         if (TextUtils.isEmpty(edtMeetingTheme.getText())) {
           edtMeetingTheme.setText(
               TextUtils.isEmpty(data.getValueString())
-                  ? SdkAuthenticator.getAccount() + "的预约会议"
+                  ? SdkAuthenticator.getAccount(null, 4) + "的预约会议"
                   : data.getValueString());
         }
         break;
@@ -186,6 +183,7 @@ public class ScheduleMeetingAdapter
         break;
       case ScheduleMeetingItem.ENABLE_MEETING_NO_SIP_ACTION:
       case ScheduleMeetingItem.ENABLE_MEETING_RECORD_ACTION:
+      case ScheduleMeetingItem.ENABLE_MEETING_WAITING_ROOM:
         sbMeetingSwitch.setVisibility(View.VISIBLE);
         sbMeetingSwitch.setChecked(data.isSwitchOn());
         break;

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/data/MeetingDataRepository.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/data/MeetingDataRepository.java
@@ -127,11 +127,11 @@ public class MeetingDataRepository {
   }
 
   public void editMeeting(NEMeetingItem item, NECallback<NEMeetingItem> callback) {
-    NEMeetingKit.getInstance().getPreMeetingService().editMeeting(item, callback);
+    NEMeetingKit.getInstance().getPreMeetingService().editMeeting(item, false, callback);
   }
 
   public void cancelMeeting(long meetingId, NECallback<Void> callback) {
-    NEMeetingKit.getInstance().getPreMeetingService().cancelMeeting(meetingId, callback);
+    NEMeetingKit.getInstance().getPreMeetingService().cancelMeeting(meetingId, false, callback);
   }
 
   public void deleteMeeting(int meetingId, NECallback<Void> callback) {}

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/data/MeetingItem.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/data/MeetingItem.java
@@ -7,6 +7,7 @@ package com.netease.yunxin.kit.meeting.sampleapp.data;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingItemLive;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingItemSetting;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingItemStatus;
+import com.netease.yunxin.kit.meeting.sdk.NEMeetingRecurringRule;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingRoleType;
 import java.io.Serializable;
 import java.util.Map;
@@ -50,9 +51,21 @@ public class MeetingItem implements Comparable<MeetingItem>, Serializable {
 
   private NEMeetingItemLive live;
 
+  private NEMeetingRecurringRule recurringRule;
+
   private boolean isGroupFirst;
 
   private boolean noSip = true;
+
+  private boolean enableWaitingRoom = false;
+
+  public void setWaitingRoomEnabled(boolean enabled) {
+    enableWaitingRoom = enabled;
+  }
+
+  public boolean isWaitingRoomEnabled() {
+    return enableWaitingRoom;
+  }
 
   private String extraData;
 
@@ -184,6 +197,14 @@ public class MeetingItem implements Comparable<MeetingItem>, Serializable {
 
   public void setLive(NEMeetingItemLive live) {
     this.live = live;
+  }
+
+  public NEMeetingRecurringRule getRecurringRule() {
+    return recurringRule;
+  }
+
+  public void setRecurringRule(NEMeetingRecurringRule recurringRule) {
+    this.recurringRule = recurringRule;
   }
 
   public void setSetting(NEMeetingItemSetting setting) {

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/data/ScheduleMeetingItem.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/data/ScheduleMeetingItem.java
@@ -48,6 +48,8 @@ public class ScheduleMeetingItem {
 
   public static final int ENABLE_MEETING_NO_SIP_ACTION = 13;
 
+  public static final int ENABLE_MEETING_WAITING_ROOM = 14;
+
   public ScheduleMeetingItem(
       String tittle,
       String subTittle,

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/menu/InjectMenuArrangeActivity.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/menu/InjectMenuArrangeActivity.java
@@ -48,7 +48,7 @@ public class InjectMenuArrangeActivity extends AppCompatActivity {
   protected ActivityMenuArrangementBinding binding;
   List<NEMeetingMenuItem> selectedItems = new ArrayList<>();
 
-  protected static int itemId = NEMenuIDs.FIRST_INJECTED_MENU_ID;
+  protected static int itemId = NEMenuIDs.FIRST_INJECTED_MENU_ID + 6;
 
   @Override
   protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -86,16 +86,15 @@ public class InjectMenuArrangeActivity extends AppCompatActivity {
     List<NEMeetingMenuItem> items = new ArrayList<>();
     items.addAll(NEMenuItems.getBuiltinToolbarMenuItemList());
     items.addAll(NEMenuItems.getBuiltinMoreMenuItemList());
-    items.add(
-        new NESingleStateMenuItem(
-            100, NEMenuVisibility.VISIBLE_ALWAYS, new NEMenuItemInfo("单选菜单", 0)));
-    items.add(
-        new NESingleStateMenuItem(
-            101, NEMenuVisibility.VISIBLE_ALWAYS, new NEMenuItemInfo("多选菜单", 0)));
-    items.add(
-        new NESingleStateMenuItem(
-            102, NEMenuVisibility.VISIBLE_ALWAYS, new NEMenuItemInfo("音频管理", 0)));
+    items.add(createMenuItem(100, "打开设置"));
+    items.add(createMenuItem(101, "最小化"));
+    items.add(createMenuItem(102, "音频管理"));
+    items.add(createMenuItem(103, "测试修改单选菜单"));
+    items.add(createMenuItem(104, "测试修改多选菜单"));
     items.add(NEMenuItems.switchShowTypeMenu());
+    items.add(createMenuItem(105, "获取账号信息"));
+    items.add(createMenuItem(106, "通用单选菜单"));
+    items.add(createMenuItem(107, "通用多选菜单"));
     FlexboxLayoutManager layoutManager = new FlexboxLayoutManager(this);
     layoutManager.setFlexDirection(FlexDirection.ROW);
     layoutManager.setJustifyContent(JustifyContent.FLEX_START);
@@ -104,13 +103,31 @@ public class InjectMenuArrangeActivity extends AppCompatActivity {
     binding.choices.setAdapter(new Adapter(this, Adapter.TYPE_CANDIDATE, items));
   }
 
+  NEMeetingMenuItem createMenuItem(int id, String text) {
+    return new NESingleStateMenuItem(
+        id, NEMenuVisibility.VISIBLE_ALWAYS, new NEMenuItemInfo(text, 0));
+  }
+
   private void selectItem(NEMeetingMenuItem item) {
     edited = true;
-    int itemId = item.getItemId();
-    if (itemId == 100) {
-      item = createSingleStateMenuItem();
-    } else if (itemId == 101) {
-      item = createCheckableMenuItem();
+    int selectId = item.getItemId();
+    switch (selectId) {
+      case 100:
+      case 101:
+      case 102:
+      case 103:
+      case 105:
+        item = createSingleStateMenuItem(selectId);
+        break;
+      case 104:
+        item = createCheckableMenuItem(selectId);
+        break;
+      case 106:
+        item = createSingleStateMenuItem(itemId++);
+        break;
+      case 107:
+        item = createCheckableMenuItem(itemId++);
+        break;
     }
     selectedItems.add(item);
     binding.selected.getAdapter().notifyItemInserted(selectedItems.size());
@@ -196,16 +213,14 @@ public class InjectMenuArrangeActivity extends AppCompatActivity {
     }
   }
 
-  protected NESingleStateMenuItem createSingleStateMenuItem() {
-    final int id = itemId++;
+  protected NESingleStateMenuItem createSingleStateMenuItem(int id) {
     return new NESingleStateMenuItem(
         id,
         NEMenuVisibility.VISIBLE_ALWAYS,
         new NEMenuItemInfo(String.valueOf(id), R.drawable.mood));
   }
 
-  protected NECheckableMenuItem createCheckableMenuItem() {
-    final int id = itemId++;
+  protected NECheckableMenuItem createCheckableMenuItem(int id) {
     return new NECheckableMenuItem(
         id,
         NEMenuVisibility.VISIBLE_ALWAYS,
@@ -360,8 +375,16 @@ public class InjectMenuArrangeActivity extends AppCompatActivity {
         return new String[] {"邀请"};
       case NEMenuIDs.CHAT_MENU_ID:
         return new String[] {"聊天"};
+      case NEMenuIDs.NOTIFY_CENTER_MENU_ID:
+        return new String[] {"通知"};
       case NEMenuIDs.WHITEBOARD_ID:
         return new String[] {"共享白板", "退出白板"};
+      case NEMenuIDs.CLOUD_RECORD_ID:
+        return new String[] {"云录制", "结束录制"};
+      case NEMenuIDs.SECURITY_ID:
+        return new String[] {"安全"};
+      case NEMenuIDs.DISCONNECT_AUDIO_ID:
+        return new String[] {"断开音频", "连接音频"};
     }
 
     if (item instanceof NESingleStateMenuItem) {

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/CommonFragment.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/CommonFragment.java
@@ -4,73 +4,15 @@
 
 package com.netease.yunxin.kit.meeting.sampleapp.view;
 
-import android.os.Bundle;
-import android.text.Editable;
-import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.TextView;
-import androidx.annotation.LayoutRes;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import com.netease.yunxin.kit.meeting.sampleapp.MeetingSettingsActivity;
-import com.netease.yunxin.kit.meeting.sampleapp.R;
 import com.netease.yunxin.kit.meeting.sampleapp.widget.LoadingDialog;
 
 public abstract class CommonFragment extends Fragment {
 
   private LoadingDialog dialog;
 
-  protected CommonFragment(@LayoutRes int contentLayoutId) {
-    super(contentLayoutId);
-  }
-
-  private EditText[] editorArray = new EditText[7];
-
-  protected abstract String getActionLabel();
-
-  protected abstract void performAction(String first, String second, String third, String fourth);
-
-  protected final EditText getEditor(int index) {
-    return editorArray[index];
-  }
-
-  protected final String getEditorText(int index) {
-    Editable text = getEditor(index).getText();
-    return text != null ? text.toString() : null;
-  }
-
-  @Override
-  public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-    super.onActivityCreated(savedInstanceState);
-
-    TextView title = getView().findViewById(R.id.title);
-    title.setText(getActionLabel());
-
-    Button action = getView().findViewById(R.id.actionBtn);
-    action.setText(getActionLabel());
-    action.setOnClickListener(
-        v ->
-            performAction(
-                getFirstEditTextContent(), getEditorText(1), getEditorText(2), getEditorText(3)));
-
-    Button actionToMeetingSettings = getView().findViewById(R.id.action_to_meeting_settings);
-    actionToMeetingSettings.setOnClickListener(v -> MeetingSettingsActivity.start(getActivity()));
-  }
-
-  protected String getFirstEditTextContent() {
-    return getEditorText(0);
-  }
-
-  protected void addEditorArray(int i, int editor, String[] labels) {
-    editorArray[i] = getView().findViewById(editor);
-    editorArray[i].setSingleLine(true);
-    if (labels.length > i) {
-      editorArray[i].setHint(labels[i]);
-    } else {
-      editorArray[i].setVisibility(View.GONE);
-    }
-  }
+  protected abstract void performAction(
+      String meetingNum, String displayName, String password, String personalTag);
 
   protected void showDialogProgress(String message) {
     if (isDialogProgressShowing()) {

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/JoinMeetingFragment.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/JoinMeetingFragment.java
@@ -7,32 +7,43 @@ package com.netease.yunxin.kit.meeting.sampleapp.view;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.ViewModelProviders;
-import com.netease.yunxin.kit.meeting.sampleapp.R;
 import com.netease.yunxin.kit.meeting.sampleapp.SdkAuthenticator;
 import com.netease.yunxin.kit.meeting.sampleapp.viewmodel.JoinMeetingViewModel;
 import com.netease.yunxin.kit.meeting.sdk.NEEncryptionConfig;
 import com.netease.yunxin.kit.meeting.sdk.NEEncryptionMode;
 import com.netease.yunxin.kit.meeting.sdk.NEJoinMeetingOptions;
 import com.netease.yunxin.kit.meeting.sdk.NEJoinMeetingParams;
+import com.netease.yunxin.kit.meeting.sdk.NEWatermarkConfig;
 
 public class JoinMeetingFragment extends MeetingCommonFragment {
-  private static final String TAG = JoinMeetingFragment.class.getSimpleName();
   private JoinMeetingViewModel mViewModel;
   private String tag;
 
+  @Nullable
   @Override
-  public void onActivityCreated(@Nullable Bundle savedInstanceState) {
-    super.onActivityCreated(savedInstanceState);
-    usePersonalMeetingNum.setEnabled(false);
+  public View onCreateView(
+      @NonNull LayoutInflater inflater,
+      @Nullable ViewGroup container,
+      @Nullable Bundle savedInstanceState) {
+    super.onCreateView(inflater, container, savedInstanceState);
+    binding.etMeetingNum.setHint("会议号");
+    binding.usePersonalMeetingNum.setEnabled(false);
     // 加入会议隐藏录制开关功能
-    (getView().findViewById(R.id.noCloudRecord)).setEnabled(false);
-    // 加入会议隐藏绑定角色
-    (getView().findViewById(R.id.roleBindTips)).setVisibility(View.GONE);
+    binding.cloudRecord.setEnabled(false);
+    binding.enableWaitingRoom.setEnabled(false);
+    // 加入会议隐藏拓展字段和绑定角色
+    binding.etExtra.setVisibility(View.GONE);
+    binding.roleBindTips.setVisibility(View.GONE);
+    binding.etRoleBind.setVisibility(View.GONE);
     mViewModel = ViewModelProviders.of(this).get(JoinMeetingViewModel.class);
     initData();
+    return binding.getRoot();
   }
 
   /** 初始化数据，为了方便测试，可通过ADB传递参数进行验证 当前支持传入tag tag:String类型 */
@@ -41,34 +52,33 @@ public class JoinMeetingFragment extends MeetingCommonFragment {
     tag = intent.getStringExtra("tag");
   }
 
-  @Override
-  protected String[] getEditorLabel() {
-    return new String[] {"会议号", "昵称", "请输入密码", "个人TAG", "媒体流加密密钥"};
-  }
-
-  @Override
   protected String getActionLabel() {
     return isAnonymous() ? "匿名入会" : "加入会议";
   }
 
   @Override
-  protected void performAction(String first, String second, String third, String fourth) {
+  protected void performAction(
+      String meetingNum, String displayName, String password, String personalTag) {
     NEJoinMeetingParams params = new NEJoinMeetingParams();
-    params.meetingNum = first;
-    params.displayName = second;
-    params.password = third;
+    params.meetingNum = meetingNum;
+    params.displayName = displayName;
+    params.password = password;
     if (!TextUtils.isEmpty(tag)) {
       params.tag = tag;
     }
-    if (!TextUtils.isEmpty(fourth)) {
-      params.tag = fourth;
+    if (!TextUtils.isEmpty(personalTag)) {
+      params.tag = personalTag;
     }
-    if (isCheckedById(R.id.cb_encryption)) {
+    if (binding.cbEncryption.isChecked()) {
       params.encryptionConfig =
-          new NEEncryptionConfig(NEEncryptionMode.GMCryptoSM4ECB, getEditorText(4));
+          new NEEncryptionConfig(
+              NEEncryptionMode.GMCryptoSM4ECB, binding.etEncryption.getText().toString());
     }
+    params.watermarkConfig =
+        new NEWatermarkConfig(SdkAuthenticator.getAccount(displayName), null, null, null);
     NEJoinMeetingOptions options =
         (NEJoinMeetingOptions) getMeetingOptions(new NEJoinMeetingOptions());
+    options.enableAudioDeviceSwitch = binding.enableAudioDeviceSwitch.isChecked();
     showDialogProgress("正在加入会议...");
     if (isAnonymous()) {
       mViewModel.anonymousJoinMeeting(params, options, new MeetingCallback());

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/MeetingSettingsFragment.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/MeetingSettingsFragment.java
@@ -130,6 +130,8 @@ public class MeetingSettingsFragment extends PreferenceFragmentCompat {
           case ENABLE_VIRTUAL_BACKGROUND:
             if (value) {
               setVirtualBackgroundPic(settingsService);
+            } else {
+              settingsService.setBuiltinVirtualBackgrounds(null);
             }
             settingsService.enableVirtualBackground(value);
             break;

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/ScheduleMeetingDetailFragment.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/ScheduleMeetingDetailFragment.java
@@ -30,6 +30,7 @@ import com.netease.yunxin.kit.meeting.sdk.NEMeetingError;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingItemStatus;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingLiveAuthLevel;
 import com.netease.yunxin.kit.meeting.sdk.NEMeetingVideoControl;
+import com.netease.yunxin.kit.meeting.sdk.NEWatermarkConfig;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -91,6 +92,8 @@ public class ScheduleMeetingDetailFragment extends BaseFragment<FragmentSchedule
           params.meetingNum = item.getMeetingNum();
           params.password = item.getPassword();
           params.displayName = SdkAuthenticator.getAccount();
+          params.watermarkConfig =
+              new NEWatermarkConfig(SdkAuthenticator.getAccount(), null, null, null);
           mViewModel.joinMeeting(params, null, new ToastCallback<>(getActivity(), "加入会议"));
         });
     binding.btnCancelScheduleMeeting.setOnClickListener(

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/ScheduleMeetingFragment.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/view/ScheduleMeetingFragment.java
@@ -57,7 +57,7 @@ public class ScheduleMeetingFragment extends BaseFragment<FragmentScheduleBindin
   private long startTime, endTime;
   private Boolean isAttendeeAudioOff, isAllowAttendeeAudioSelfOn;
   private Boolean isAttendeeVideoOff, isAllowAttendeeVideoSelfOn;
-  private boolean isUsePwd, isLiveOn, isLiveLevelOpen, isOpenRecord, isEnableSip;
+  private boolean isUsePwd, isLiveOn, isLiveLevelOpen, isOpenRecord, isEnableSip, enableWaitingRoom;
   private NESettingsService settingsService;
   private boolean isEditMeeting = false;
   private MeetingItem item = null;
@@ -177,6 +177,9 @@ public class ScheduleMeetingFragment extends BaseFragment<FragmentScheduleBindin
               case ScheduleMeetingItem.ENABLE_MEETING_NO_SIP_ACTION:
                 isEnableSip = enable;
                 break;
+              case ScheduleMeetingItem.ENABLE_MEETING_WAITING_ROOM:
+                enableWaitingRoom = enable;
+                break;
             }
           }
         });
@@ -247,6 +250,7 @@ public class ScheduleMeetingFragment extends BaseFragment<FragmentScheduleBindin
                   isLiveLevelOpen ? NEMeetingLiveAuthLevel.appToken : NEMeetingLiveAuthLevel.token);
               neMeetingItem.setLive(live);
               neMeetingItem.setNoSip(!isEnableSip);
+              neMeetingItem.setWaitingRoomEnabled(enableWaitingRoom);
               if (isEditMeeting) {
                 mViewModel.editMeeting(
                     neMeetingItem,
@@ -341,6 +345,12 @@ public class ScheduleMeetingFragment extends BaseFragment<FragmentScheduleBindin
             "开启SIP",
             (item != null && !item.isNoSip()),
             ScheduleMeetingItem.ENABLE_MEETING_NO_SIP_ACTION,
+            ""));
+    dataList.add(
+        new ScheduleMeetingItem(
+            "开启等候室",
+            (item != null && item.isWaitingRoomEnabled()),
+            ScheduleMeetingItem.ENABLE_MEETING_WAITING_ROOM,
             ""));
     dataList.add(
         new ScheduleMeetingItem(

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/viewmodel/HomeViewModel.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/viewmodel/HomeViewModel.java
@@ -71,9 +71,11 @@ public class HomeViewModel extends ViewModel {
         item.setDay(startTime.substring(8, 10));
         item.setSetting(neMeetingItem.getSetting());
         item.setLive(neMeetingItem.getLive());
+        item.setRecurringRule(neMeetingItem.getRecurringRule());
         item.setExtraData(neMeetingItem.getExtraData());
         item.setRoleBinds(neMeetingItem.getRoleBinds());
         item.setNoSip(neMeetingItem.noSip());
+        item.setWaitingRoomEnabled(neMeetingItem.isWaitingRoomEnabled());
         items.add(item);
       }
       Collections.sort(items);

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/viewmodel/MainViewModel.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/viewmodel/MainViewModel.java
@@ -128,7 +128,8 @@ public class MainViewModel extends ViewModel
     LogUtil.log(TAG, "onMeetingStatusChanged: " + status + "==" + minimizedLiveData.getValue());
     Boolean value =
         status == NEMeetingStatus.MEETING_STATUS_INMEETING_MINIMIZED
-            || status == NEMeetingStatus.MEETING_STATUS_INMEETING;
+            || status == NEMeetingStatus.MEETING_STATUS_INMEETING
+            || status == NEMeetingStatus.MEETING_STATUS_IN_WAITING_ROOM;
     if (minimizedLiveData.getValue() != value) {
       minimizedLiveData.setValue(value);
     }

--- a/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/viewmodel/ScheduleViewModel.java
+++ b/SampleCode/Android/app/src/main/java/com/netease/yunxin/kit/meeting/sampleapp/viewmodel/ScheduleViewModel.java
@@ -35,6 +35,7 @@ public class ScheduleViewModel extends ViewModel {
     meetingItem.setEndTime(item.getEndTime());
     meetingItem.setExtraData(item.getExtraData());
     meetingItem.setLive(item.getLive());
+    meetingItem.setRecurringRule(item.getRecurringRule());
     meetingItem.setPassword(item.getPassword());
     meetingItem.setSetting(item.getSetting());
     meetingItem.setSubject(item.getSubject());

--- a/SampleCode/Android/app/src/main/res/layout/fragment_meeting_base.xml
+++ b/SampleCode/Android/app/src/main/res/layout/fragment_meeting_base.xml
@@ -7,8 +7,7 @@
         xmlns:tools="http://schemas.android.com/tools"
         android:id="@+id/joinMeetingFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context="com.netease.meeting.demo.com.netease.meeting.sampleapp.view.JoinMeetingFragment">
+        android:layout_height="match_parent">
 
     <ScrollView
             android:fillViewport="true"
@@ -83,7 +82,7 @@
                     android:text="打开麦克风" />
 
             <CheckBox
-                    android:id="@+id/usePersonalMeetingId"
+                    android:id="@+id/usePersonalMeetingNum"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:enabled="false"
@@ -168,10 +167,22 @@
                     android:text="关闭会中改名" />
 
             <CheckBox
-                    android:id="@+id/noCloudRecord"
+                    android:id="@+id/cloudRecord"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="开启云录制" />
+
+            <CheckBox
+                android:id="@+id/showCloudRecordingUI"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="显示云录制过程UI" />
+
+            <CheckBox
+                android:id="@+id/showCloudRecordMenuItem"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="显示云录制菜单按钮" />
 
             <CheckBox
                     android:id="@+id/noSip"
@@ -318,6 +329,20 @@
                 android:text="开启加密"
                 android:checked="false" />
 
+            <CheckBox
+                    android:id="@+id/enableWaitingRoom"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="开启等候室"
+                    android:checked="false" />
+
+            <CheckBox
+                android:id="@+id/enableAudioDeviceSwitch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="允许音频设备切换"
+                android:checked="true" />
+
             <androidx.constraintlayout.helper.widget.Flow
                     android:id="@+id/checkbox_flow_1"
                     android:layout_width="0dp"
@@ -327,7 +352,7 @@
                     android:orientation="vertical"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toLeftOf="@+id/checkbox_flow_2"
-                    app:layout_constraintTop_toBottomOf="@+id/roleBind"
+                    app:layout_constraintTop_toBottomOf="@+id/et_role_bind"
                     app:layout_constraintBottom_toTopOf="@+id/configToolbarMenus"
                     app:flow_wrapMode="none"
                     app:flow_verticalGap="8dp"
@@ -337,7 +362,7 @@
                     app:flow_verticalStyle="packed"
                     app:flow_verticalAlign="top"
                     app:layout_constraintHorizontal_weight="1"
-                    app:constraint_referenced_ids="videoOption,audioOption,usePersonalMeetingId,useDefaultOptions,noChatOptions,disableImageMessage,disableFileMessage,no_minimize,noInviteOptions,show_meeting_time,showLongMeetingIdOnly,showShortMeetingIdOnly,noGalleryOptions,noSwitchCamera,noSwitchAudioMode,noRename,enableTransparentWhiteboard,enableFrontCameraMirror,noLive,cb_encryption" />
+                    app:constraint_referenced_ids="videoOption,audioOption,usePersonalMeetingNum,useDefaultOptions,noChatOptions,disableImageMessage,disableFileMessage,no_minimize,noInviteOptions,show_meeting_time,showLongMeetingIdOnly,showShortMeetingIdOnly,noGalleryOptions,noSwitchCamera,noSwitchAudioMode,noRename,enableTransparentWhiteboard,enableFrontCameraMirror,noLive,cb_encryption,enableWaitingRoom" />
 
             <androidx.constraintlayout.helper.widget.Flow
                     android:id="@+id/checkbox_flow_2"
@@ -354,12 +379,12 @@
                     app:flow_maxElementsWrap="1"
                     app:flow_verticalStyle="packed"
                     app:layout_constraintHorizontal_weight="1"
-                    app:constraint_referenced_ids="noCloudRecord,noSip,noWhiteBoard,defaultWhiteBoard,showMemberTag,showMeetingRemainingTip,audioOffNotAllowSelfOn,audioOffAllowSelfOn,videoOffAllowSelfOn,videoOffNotAllowSelfOn,noMuteAllVideo,noMuteAllAudio,detectMutedMic,unpubAudioOnMute,showScreenShareUserVideo,showWhiteboardShareUserVideo,showFloatingMicrophone,enableAudioShare" />
+                    app:constraint_referenced_ids="cloudRecord,showCloudRecordingUI,showCloudRecordMenuItem,noSip,noWhiteBoard,defaultWhiteBoard,showMemberTag,showMeetingRemainingTip,audioOffNotAllowSelfOn,audioOffAllowSelfOn,videoOffAllowSelfOn,videoOffNotAllowSelfOn,noMuteAllVideo,noMuteAllAudio,detectMutedMic,unpubAudioOnMute,showScreenShareUserVideo,showWhiteboardShareUserVideo,showFloatingMicrophone,enableAudioShare,enableAudioDeviceSwitch" />
 
 
 
             <EditText
-                    android:id="@+id/firstEditor"
+                    android:id="@+id/et_meeting_num"
                     android:layout_width="0dp"
                     android:layout_height="56dp"
                     android:layout_margin="10dp"
@@ -370,28 +395,28 @@
                     tools:hint="会议号" />
 
             <EditText
-                    android:id="@+id/secondEditor"
+                    android:id="@+id/et_nickname"
                     android:layout_width="0dp"
                     android:layout_height="56dp"
                     android:layout_margin="10dp"
                     android:textSize="16sp"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/firstEditor"
+                    app:layout_constraintTop_toBottomOf="@id/et_meeting_num"
                     tools:text="1234567" />
 
             <EditText
-                    android:id="@+id/thirdEditor"
+                    android:id="@+id/et_password"
                     android:layout_width="0dp"
                     android:layout_height="56dp"
                     android:layout_margin="10dp"
                     android:textSize="16sp"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/secondEditor" />
+                    app:layout_constraintTop_toBottomOf="@id/et_nickname" />
 
             <EditText
-                    android:id="@+id/fourthEditor"
+                    android:id="@+id/et_personal_tag"
                     android:layout_width="0dp"
                     android:layout_height="56dp"
                     android:layout_margin="10dp"
@@ -399,10 +424,10 @@
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
                     tools:hint="个人TAG"
-                    app:layout_constraintTop_toBottomOf="@id/thirdEditor" />
+                    app:layout_constraintTop_toBottomOf="@id/et_password" />
 
             <EditText
-                    android:id="@+id/fifthEditor"
+                    android:id="@+id/et_extra"
                     android:layout_width="0dp"
                     android:layout_height="56dp"
                     android:layout_margin="10dp"
@@ -410,7 +435,7 @@
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
                     tools:hint="扩展字段"
-                    app:layout_constraintTop_toBottomOf="@id/fourthEditor" />
+                    app:layout_constraintTop_toBottomOf="@id/et_personal_tag" />
 
             <TextView
                     android:id="@+id/roleBindTips"
@@ -422,10 +447,10 @@
                     android:textStyle="bold"
                     android:text="会议成员角色绑定0:主持人，1:联席主持人，2：成员"
                     app:layout_constraintLeft_toLeftOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/fifthEditor" />
+                    app:layout_constraintTop_toBottomOf="@id/et_extra" />
 
             <EditText
-                    android:id="@+id/roleBind"
+                    android:id="@+id/et_role_bind"
                     android:layout_width="0dp"
                     android:layout_height="56dp"
                     android:layout_margin="10dp"

--- a/SampleCode/Android/build.gradle
+++ b/SampleCode/Android/build.gradle
@@ -1,15 +1,26 @@
+// Copyright (c) 2022 NetEase, Inc. All rights reserved.
+// Use of this source code is governed by a MIT license that can be
+// found in the LICENSE file.
+
+import java.util.function.IntBinaryOperator
+import java.util.function.ToIntFunction
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
         kotlin_version = '1.6.21'
     }
     repositories {
-        google()
         mavenCentral()
+        google()
+        mavenLocal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.3.0'
+
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/SampleCode/Android/gradle.properties
+++ b/SampleCode/Android/gradle.properties
@@ -1,3 +1,7 @@
+# Copyright (c) 2022 NetEase, Inc. All rights reserved.
+# Use of this source code is governed by a MIT license that can be
+# found in the LICENSE file.
+
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*
@@ -7,6 +11,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m
+org.gradle.parallel=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -17,7 +22,23 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.nonTransitiveRClass=true
 
 # Android Gradle Plugin 3.6.0 uses a new packaging tool, called zipflinger for debug build
 # But for now, it make an error when build
-android.useNewApkCreator=false
+#android.useNewApkCreator=false
+
+# Remove testOnly attribute from application tag
+android.injected.testOnly=false
+
+# Use official kotlin style
+kotlin.code.style=official
+
+# define the version name
+# eg. major.minor.hotfix{.buildNum}
+# eg. 1.0.0.0
+# eg. 1.0.0
+VERSION_NAME=4.4.0
+android.suppressUnsupportedCompileSdk=34
+#versionSuffix=SNAPSHOT
+#generateJavaDoc=false


### PR DESCRIPTION
New Feature
入会时支持指定参会者头像
入会时支持是否允许音频设备切换
支持会中锁定特定用户视频画面
支持会议创建者收回主持人权限
预约会议支持配置是否允许参会者在主持人进会前加入会议
Android 升级适配 TargetSdk 至 API 34 （Android 14）
支持会中全部准入、全部移除等候室成员
支持本次会议自动准入等候室成员
支持聊天室私聊功能和聊天权限控制
支持主持人在会议发起内签到功能
支持预约周期性会议
支持会议中黑名单
Fixed
修复移动端等候室默认图片展示未撑满屏幕的问题
适配 Android 机型导航栏沉浸式模式
修复移动端参会者列表添加“焦点视频”成员图标
修复 Android 5.x 系统白板共享黑屏问题（Flutter渲染PlatformView 失败）
兼容处理 会中聊天室/等候室聊天室 可能不存在的情况